### PR TITLE
Cancel arena block break+place

### DIFF
--- a/src/main/java/dev/dpvb/survival/game/GameListener.java
+++ b/src/main/java/dev/dpvb/survival/game/GameListener.java
@@ -84,16 +84,28 @@ public class GameListener implements Listener {
         }
     }
 
-    // Allow gamers to "place" TNT in the arena.
+    // Allow gamers to place TNT in the arena.
     @EventHandler
-    public void onTntPlace(BlockPlaceEvent event) {
+    public void onTntWouldPlace(BlockPlaceEvent event) {
+        final var player = event.getPlayer();
+        if (!manager.playerInGame(player)) return;
+        if (event.getBlockPlaced().getType() == Material.TNT && event.isCancelled()) {
+            // Re-allow place
+            event.setCancelled(false);
+        }
+    }
+
+    // Change placement into "placement" (spawning of TNTPrimed)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
+    public void onTntPlacement(BlockPlaceEvent event) {
         final var player = event.getPlayer();
         if (!manager.playerInGame(player)) return;
         if (event.getBlockPlaced().getType() == Material.TNT) {
-            event.getBlock().setType(Material.AIR);
-            // spawn tnt
-            Entity tnt = manager.getArenaWorld().spawn(event.getBlock().getLocation(), TNTPrimed.class);
-            ((TNTPrimed) tnt).setFuseTicks(50);
+            // Prevent actual placement (still use item)
+            event.getBlockReplacedState().update(true);
+            // spawn TNTPrimed
+            TNTPrimed tnt = manager.getArenaWorld().spawn(event.getBlock().getLocation(), TNTPrimed.class);
+            tnt.setFuseTicks(50);
         }
     }
 

--- a/src/main/java/dev/dpvb/survival/game/GameListener.java
+++ b/src/main/java/dev/dpvb/survival/game/GameListener.java
@@ -104,7 +104,7 @@ public class GameListener implements Listener {
             // Prevent actual placement (still use item)
             event.getBlockReplacedState().update(true);
             // spawn TNTPrimed
-            TNTPrimed tnt = manager.getArenaWorld().spawn(event.getBlock().getLocation(), TNTPrimed.class);
+            TNTPrimed tnt = manager.getArenaWorld().spawn(event.getBlock().getLocation().add(0.5d, 0d, 0.5d), TNTPrimed.class);
             tnt.setFuseTicks(50);
         }
     }

--- a/src/main/java/dev/dpvb/survival/game/GameListener.java
+++ b/src/main/java/dev/dpvb/survival/game/GameListener.java
@@ -5,7 +5,9 @@ import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -59,6 +61,30 @@ public class GameListener implements Listener {
         }
     }
 
+    // Always prevent block places and block breaks for hub and arena worlds.
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        if (event.getPlayer().hasPermission("survival.bypass")) {
+            return;
+        }
+        final var world = event.getBlock().getWorld();
+        if (world == manager.hubWorld || world == manager.arenaWorld) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+    public void onBlockPlace(BlockBreakEvent event) {
+        if (event.getPlayer().hasPermission("survival.bypass")) {
+            return;
+        }
+        final var world = event.getBlock().getWorld();
+        if (world == manager.hubWorld || world == manager.arenaWorld) {
+            event.setCancelled(true);
+        }
+    }
+
+    // Allow gamers to "place" TNT in the arena.
     @EventHandler
     public void onTntPlace(BlockPlaceEvent event) {
         final var player = event.getPlayer();

--- a/src/main/java/dev/dpvb/survival/game/GameManager.java
+++ b/src/main/java/dev/dpvb/survival/game/GameManager.java
@@ -23,7 +23,7 @@ public class GameManager {
 
     private static GameManager instance;
     final World hubWorld;
-    private final World arenaWorld;
+    final World arenaWorld;
     private final Set<Player> players = new HashSet<>();
     private final Set<Extraction> extractions = new HashSet<>();
     private final List<Location> spawnLocations = new ArrayList<>();


### PR DESCRIPTION
* Cancel breaking and placing of blocks within the hub and arena worlds; permission node exclusion
* Designed with low priority--if we need to allow specific blocks in another listener we can
* Continues #25 